### PR TITLE
Rewrite for SDK Updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -193,12 +193,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nexcess/nexcess-php-sdk.git",
-                "reference": "4359c2472ab84427e464ebb1ab308dfc2ca83ed6"
+                "reference": "52c66ee952a75e4e2859a19b37d91d86671be13a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nexcess/nexcess-php-sdk/zipball/4359c2472ab84427e464ebb1ab308dfc2ca83ed6",
-                "reference": "4359c2472ab84427e464ebb1ab308dfc2ca83ed6",
+                "url": "https://api.github.com/repos/nexcess/nexcess-php-sdk/zipball/52c66ee952a75e4e2859a19b37d91d86671be13a",
+                "reference": "52c66ee952a75e4e2859a19b37d91d86671be13a",
                 "shasum": ""
             },
             "require": {
@@ -238,7 +238,7 @@
                 "source": "https://github.com/nexcess/nexcess-php-sdk/tree/master",
                 "issues": "https://github.com/nexcess/nexcess-php-sdk/issues"
             },
-            "time": "2018-11-01T14:43:22+00:00"
+            "time": "2018-11-01T16:18:49+00:00"
         },
         {
             "name": "php-enspired/exceptable",

--- a/src/Command/CloudAccount/Backup/Create.php
+++ b/src/Command/CloudAccount/Backup/Create.php
@@ -83,10 +83,12 @@ class Create extends CreateCommand {
 
     $app->say($this->getPhrase('creating'));
     $backup = $endpoint->createBackup($model)
+      ->then(function ($backup) use ($input) {
+        $this->_saySummary($backup->toArray(), $input->getOption('json'));
+        return $backup;
+      })
       ->then($then_download)
       ->wait();
-
-    $this->_saySummary($backup->toArray(), $input->getOption('json'));
 
     return Console::EXIT_SUCCESS;
   }

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -27,6 +27,8 @@
           "creating":"Creating",
           "created":"Created",
           "desc": "Create a new backup for a given cloud account",
+          "downloading": "Downloading backup... ",
+          "download_complete": "download complete:\n  {file}",
           "help": "Creates a new backup for a cloud account and optionally downloads it when complete. The given download path must exist and be writable.",
           "opt_cloud_account_id": "Cloud Account ID",
           "opt_download": "Local filesystem path to download backup to",


### PR DESCRIPTION
Updates to SDK allow us to eliminate custom `waitUntil` and reduce download callback to `$backup->download()`.

Also added some output indicating download was in progress, and where the file was saved locally.